### PR TITLE
add support for customising json parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,45 @@
+# A quick note
+
+Please don't use this in a new application.
+
+This fork of `rack-contrib` provides the ability to customise JSON parsing in `Rack::PostBodyContentTypeParser` for applications which due to dependency issues are unable to upgrade to later versions of `rack-contrib`.
+
 # Contributed Rack Middleware and Utilities
 
 This package includes a variety of add-on components for Rack, a Ruby web server
 interface:
 
-* `Rack::AcceptFormat` - Adds a format extension at the end of the URI when there is none, corresponding to the mime-type given in the Accept HTTP header.
-* `Rack::Access` - Limits access based on IP address
-* `Rack::Backstage` - Returns content of specified file if it exists, which makes it convenient for putting up maintenance pages.
-* `Rack::BounceFavicon` - Returns a 404 for requests to `/favicon.ico`
-* `Rack::CSSHTTPRequest` - Adds CSSHTTPRequest support by encoding responses as CSS for cross-site AJAX-style data loading
-* `Rack::Callbacks` - Implements DSL for pure before/after filter like Middlewares.
-* `Rack::Config` - Shared configuration for cooperative middleware.
-* `Rack::Cookies` - Adds simple cookie jar hash to env
-* `Rack::Deflect` - Helps protect against DoS attacks.
-* `Rack::Evil` - Lets the rack application return a response to the client from any place.
-* `Rack::HostMeta` - Configures `/host-meta` using a block
-* `Rack::JSONP` - Adds JSON-P support by stripping out the callback param and padding the response with the appropriate callback format.
-* `Rack::LazyConditionalGet` - Caches a global `Last-Modified` date and updates it each time there is a request that is not `GET` or `HEAD`.
-* `Rack::LighttpdScriptNameFix` - Fixes how lighttpd sets the `SCRIPT_NAME` and `PATH_INFO` variables in certain configurations.
-* `Rack::Locale` - Detects the client locale using the Accept-Language request header and sets a `rack.locale` variable in the environment.
-* `Rack::MailExceptions` - Rescues exceptions raised from the app and sends a useful email with the exception, stacktrace, and contents of the environment.
-* `Rack::NestedParams` - parses form params with subscripts (e.g., * "`post[title]=Hello`") into a nested/recursive Hash structure (based on Rails' implementation).
-* `Rack::NotFound` - A default 404 application.
-* `Rack::PostBodyContentTypeParser` - Adds support for JSON request bodies. The Rack parameter hash is populated by deserializing the JSON data provided in the request body when the Content-Type is application/json.
-* `Rack::Printout` - Prints the environment and the response per request
-* `Rack::ProcTitle` - Displays request information in process title (`$0`) for monitoring/inspection with ps(1).
-* `Rack::Profiler` - Uses ruby-prof to measure request time.
-* `Rack::RelativeRedirect` - Transforms relative paths in redirects to absolute URLs.
-* `Rack::ResponseCache` - Caches responses to requests without query strings to Disk or a user provider Ruby object. Similar to Rails' page caching.
-* `Rack::ResponseHeaders` - Manipulates response headers object at runtime
-* `Rack::Sendfile` - Enables `X-Sendfile` support for bodies that can be served from file.
-* `Rack::Signals` - Installs signal handlers that are safely processed after a request
-* `Rack::SimpleEndpoint` - Creates simple endpoints with routing rules, similar to Sinatra actions
-* `Rack::StaticCache` - Modifies the response headers to facilitiate client and proxy caching for static files that minimizes http requests and improves overall load times for second time visitors.
-* `Rack::TimeZone` - Detects the client's timezone using JavaScript and sets a variable in Rack's environment with the offset from UTC.
-* `Rack::TryStatic` - Tries to match request to a static file
+- `Rack::AcceptFormat` - Adds a format extension at the end of the URI when there is none, corresponding to the mime-type given in the Accept HTTP header.
+- `Rack::Access` - Limits access based on IP address
+- `Rack::Backstage` - Returns content of specified file if it exists, which makes it convenient for putting up maintenance pages.
+- `Rack::BounceFavicon` - Returns a 404 for requests to `/favicon.ico`
+- `Rack::CSSHTTPRequest` - Adds CSSHTTPRequest support by encoding responses as CSS for cross-site AJAX-style data loading
+- `Rack::Callbacks` - Implements DSL for pure before/after filter like Middlewares.
+- `Rack::Config` - Shared configuration for cooperative middleware.
+- `Rack::Cookies` - Adds simple cookie jar hash to env
+- `Rack::Deflect` - Helps protect against DoS attacks.
+- `Rack::Evil` - Lets the rack application return a response to the client from any place.
+- `Rack::HostMeta` - Configures `/host-meta` using a block
+- `Rack::JSONP` - Adds JSON-P support by stripping out the callback param and padding the response with the appropriate callback format.
+- `Rack::LazyConditionalGet` - Caches a global `Last-Modified` date and updates it each time there is a request that is not `GET` or `HEAD`.
+- `Rack::LighttpdScriptNameFix` - Fixes how lighttpd sets the `SCRIPT_NAME` and `PATH_INFO` variables in certain configurations.
+- `Rack::Locale` - Detects the client locale using the Accept-Language request header and sets a `rack.locale` variable in the environment.
+- `Rack::MailExceptions` - Rescues exceptions raised from the app and sends a useful email with the exception, stacktrace, and contents of the environment.
+- `Rack::NestedParams` - parses form params with subscripts (e.g., \* "`post[title]=Hello`") into a nested/recursive Hash structure (based on Rails' implementation).
+- `Rack::NotFound` - A default 404 application.
+- `Rack::PostBodyContentTypeParser` - Adds support for JSON request bodies. The Rack parameter hash is populated by deserializing the JSON data provided in the request body when the Content-Type is application/json.
+- `Rack::Printout` - Prints the environment and the response per request
+- `Rack::ProcTitle` - Displays request information in process title (`$0`) for monitoring/inspection with ps(1).
+- `Rack::Profiler` - Uses ruby-prof to measure request time.
+- `Rack::RelativeRedirect` - Transforms relative paths in redirects to absolute URLs.
+- `Rack::ResponseCache` - Caches responses to requests without query strings to Disk or a user provider Ruby object. Similar to Rails' page caching.
+- `Rack::ResponseHeaders` - Manipulates response headers object at runtime
+- `Rack::Sendfile` - Enables `X-Sendfile` support for bodies that can be served from file.
+- `Rack::Signals` - Installs signal handlers that are safely processed after a request
+- `Rack::SimpleEndpoint` - Creates simple endpoints with routing rules, similar to Sinatra actions
+- `Rack::StaticCache` - Modifies the response headers to facilitiate client and proxy caching for static files that minimizes http requests and improves overall load times for second time visitors.
+- `Rack::TimeZone` - Detects the client's timezone using JavaScript and sets a variable in Rack's environment with the offset from UTC.
+- `Rack::TryStatic` - Tries to match request to a static file
 
 ### Use
 
@@ -67,7 +73,7 @@ To contribute to the project, begin by cloning the repo and installing the neces
 
     gem install json rack ruby-prof test-spec test-unit
 
-To run the entire test suite, run 
+To run the entire test suite, run
 
     rake test
 
@@ -75,26 +81,28 @@ To run a specific component's tests run
 
     specrb -Ilib:test -w test/spec_rack_thecomponent.rb
 
-This works on ruby 1.8.7 but has problems under ruby 1.9.x. 
+This works on ruby 1.8.7 but has problems under ruby 1.9.x.
 
 TODO: instructions for 1.9.x and include bundler
 
 ### Criteria for inclusion
+
 The criteria for middleware being included in this project are roughly as follows:
-* For patterns that are very common, provide a reference implementation so that other projects do not have to reinvent the wheel.
-* For patterns that are very useful or interesting, provide a well-done implementation.
-* The middleware fits in 1 code file and is relatively small. Currently all middleware in the project are < 150 LOC.
-* The middleware doesn't have any dependencies other than rack and the ruby standard library.
+
+- For patterns that are very common, provide a reference implementation so that other projects do not have to reinvent the wheel.
+- For patterns that are very useful or interesting, provide a well-done implementation.
+- The middleware fits in 1 code file and is relatively small. Currently all middleware in the project are < 150 LOC.
+- The middleware doesn't have any dependencies other than rack and the ruby standard library.
 
 These criteria were introduced several years after the start of the project, so some of the included middleware may not meet all of them. In particular, several middleware have external dependencies. It is possible that in some future release of rack-contrib, middleware with external depencies will be removed from the project.
 
 When submitting code keep the above criteria in mind and also see the code
-guidelines in CONTRIBUTING.md. 
+guidelines in CONTRIBUTING.md.
 
 ### Links
 
-* rack-contrib on GitHub:: <http://github.com/rack/rack-contrib>
-* Rack:: <http://rack.rubyforge.org/>
-* Rack On GitHub:: <http://github.com/rack/rack>
-* rack-devel mailing list:: <http://groups.google.com/group/rack-devel>
-* [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/rack/rack-contrib?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+- rack-contrib on GitHub:: <http://github.com/rack/rack-contrib>
+- Rack:: <http://rack.rubyforge.org/>
+- Rack On GitHub:: <http://github.com/rack/rack>
+- rack-devel mailing list:: <http://groups.google.com/group/rack-devel>
+- [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/rack/rack-contrib?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/lib/rack/contrib/post_body_content_type_parser.rb
+++ b/lib/rack/contrib/post_body_content_type_parser.rb
@@ -24,14 +24,15 @@ module Rack
     #
     APPLICATION_JSON = 'application/json'.freeze
 
-    def initialize(app)
+    def initialize(app, &block)
       @app = app
+      @block = block || Proc.new { |body| JSON.parse(body, create_additions: false) }
     end
 
     def call(env)
       if Rack::Request.new(env).media_type == APPLICATION_JSON && (body = env[POST_BODY].read).length != 0
         env[POST_BODY].rewind # somebody might try to read this stream
-        env.update(FORM_HASH => JSON.parse(body, :create_additions => false), FORM_INPUT => env[POST_BODY])
+        env.update(FORM_HASH => @block.call(body), FORM_INPUT => env[POST_BODY])
       end
       @app.call(env)
     rescue JSON::ParserError


### PR DESCRIPTION
We currently have an issue with one of our legacy applications where we need to customise the JSON parsing handled by `rack-contrib`. This is available in later versions of `rack-contrib`

Unfortunately that app has a requirement on `rack` versions before `2.0` and due to the unique dependencies of our legacy apps it's not possible to update `rack` without significant difficulty.

This PR and fork of `rack-contrib` makes it possible for us to customise JSON parsing, while using earlier versions of rack.

